### PR TITLE
changes to load only active profile-specific dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,18 +17,6 @@
         <java.version>11</java.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.azure.spring</groupId>
-                <artifactId>spring-cloud-azure-dependencies</artifactId>
-                <version>4.13.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
 
         <dependency>
@@ -41,10 +29,6 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.azure.spring</groupId>
-            <artifactId>spring-cloud-azure-starter-jdbc-mysql</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>
@@ -90,6 +74,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>azure</id>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.azure.spring</groupId>
+                        <artifactId>spring-cloud-azure-dependencies</artifactId>
+                        <version>4.13.0</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.azure.spring</groupId>
+                    <artifactId>spring-cloud-azure-starter-jdbc-mysql</artifactId>
+                </dependency>
+            </dependencies>
+
+        </profile>
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
closes #19 

We should only load dependencies that are specific to a profile. For example, we might not need the azure dependencies when we have an active aws / localh2db profile. 